### PR TITLE
Add devlog on AI-powered MVP building and community hub vision

### DIFF
--- a/app/b/devlog-ai-mvp-cafe/page.mdx
+++ b/app/b/devlog-ai-mvp-cafe/page.mdx
@@ -1,0 +1,52 @@
+import { AnimatedName } from "../components/animated-name.tsx";
+import { BlogMeta } from "../components/BlogComponents";
+
+export const metadata = {
+  title: "Devlog #4 – MVP-uri la viteza AI și visul unui hub-cafenea pentru devs",
+  date: "2025-06-10",
+  author: "Alexandru Cătălin Stroe",
+  tags: ["devlog", "ai", "mvp", "community", "entrepreneurship"],
+};
+
+<BlogMeta {...metadata} />
+
+<AnimatedName />
+
+# Devlog #4 – MVP-uri la viteza AI și visul unui hub-cafenea pentru devs
+
+Săptămâna asta am avut o revelație foarte practică: **nu a mai fost niciodată atât de ușor să lansezi un MVP**. Modelele AI generative îmi oferă nu doar idei, ci și cod funcțional, structuri de baze de date și chiar pitch deck-uri de test. În loc să blochez o săptămână pe un feature, pot itera în ore.
+
+## Cum folosesc AI-ul ca motor de prototipare
+
+Am standardizat un flow simplu:
+
+1. Îi descriu lui GPT problema, contextul de business și indicatorii pe care vreau să-i validezi.
+2. Îi cer o arhitectură tehnică și un plan de implementare pe zile.
+3. Generez componentele-cheie: scheme de date, endpoints, UI starter și prompturi pentru agenți.
+4. Conectez totul într-un repo-template pe care l-am optimizat deja pentru deploy rapid.
+
+În paralel, mă folosesc de modele specializate pentru generarea de copy, imagini și chiar scripturi de outreach. În 48 de ore am ridicat două MVP-uri funcționale, fiecare cu landing page, onboarding și primele automatizări de marketing.
+
+## De ce mă gândesc la o casă-cafenea pentru dev build nights
+
+În timp ce construiesc, realizez că **momentul ideal pentru o comunitate fizică de builders este chiar acum**. Mă bate gândul serios să închiriez o casă veche din București și să o transform într-o cafenea de zi / hub de noapte pentru dezvoltatori și fondatori tehnici.
+
+Văd locul ca pe un "third place" cu espresso bun, internet stabil și mult spațiu de whiteboard. Ziua ar fi un coworking relaxat, iar seara am organizat mini-hackathoane în jurul unor idei care pot deveni business în două săptămâni. AI-ul scade bariera tehnică, dar avem nevoie de:
+
+- context local și feedback real de la oameni care construiesc;
+- disciplină de ship-uit constant;
+- parteneriate cu antreprenori care pot valida rapid piața;
+- un spațiu unde ideile nu mor în draft, ci devin prototipuri testabile.
+
+## Planul pentru următoarele săptămâni
+
+În jurul acestei idei se conturează deja câteva direcții:
+
+- **Pilot de weekend** – vreau să testez formatul cu un grup mic de prieteni devs și să vedem cum funcționează ritmul build & ship.
+- **Program AI-first MVP** – documentez fiecare pas din flow-ul meu de prototipare și îl transform într-un ghid pentru oricine vine în spațiu.
+- **Parteneriate locale** – discut cu prieteni din real estate și horeca să văd costuri, licențe și cum putem face locul sustenabil.
+- **Newsletter dedicat** – voi trimite update-uri săptămânale cu idei de MVP-uri, resurse AI și progresul spațiului.
+
+Dacă reușesc să pun pe picioare casa-cafenea, cred că putem crea un nucleu de builders care să lanseze produse reale, nu doar proiecte de portofoliu. AI-ul ne oferă turbo-boost-ul, dar **energia comunității** e ceea ce poate transforma prototipurile în business-uri viabile.
+
+Rămân cu entuziasmul la cote maxime și cu un calendar plin de micro-experimente. Ne auzim curând cu update-uri din pilotul cafenelei!

--- a/app/page.mdx
+++ b/app/page.mdx
@@ -12,6 +12,7 @@ Sunt full stack developer și îmi place să dezvolt aplicații și tool-uri, au
 
 ## Dev Log
 
+- [Devlog #4 – MVP-uri la viteza AI și visul unui hub-cafenea pentru devs](/b/devlog-ai-mvp-cafe)
 - [Primul post este cel mai greu](/b/first-post)
 - [Devlog #3 – Cum mi-am automatizat publicarea devlog-ului direct din Codex](/b/codex-automation)
 - [LLM Testing](/b/test-mdx)


### PR DESCRIPTION
## Summary
- add a new devlog entry about accelerating MVP development with AI and plans for a developer cafe
- surface the new article in the home page dev log list

## Testing
- `pnpm build` *(fails: unable to download Inter font from Google Fonts in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfde84635483259e1bf9b991b8e927